### PR TITLE
Details validation for responses

### DIFF
--- a/src/wamp.app.src
+++ b/src/wamp.app.src
@@ -1,6 +1,6 @@
 {application, wamp,
  [{description, "An OTP library implementing WAMP message encoding and decoding."},
-  {vsn, "1.0.0"},
+  {vsn, "1.0.1"},
   {registered, []},
   {mod, {wamp_app, []}},
   {applications,

--- a/src/wamp_details.erl
+++ b/src/wamp_details.erl
@@ -133,7 +133,8 @@ validate(goodbye, Details, Extensions) ->
 
 validate(error, Details, Extensions) ->
     Spec = ?ERROR_DETAILS_SPEC,
-    wamp_utils:validate_map(Details, Spec, Extensions);
+    Opts = #{keep_unknown => true},
+    wamp_utils:validate_map(Details, Spec, Extensions, Opts);
 
 validate(event, Details, Extensions) ->
     Spec = ?EVENT_DETAILS_SPEC,
@@ -149,7 +150,8 @@ validate(subscriber_received, Details, Extensions) ->
 
 validate(result, Details, Extensions) ->
     Spec = ?RESULT_DETAILS_SPEC,
-    wamp_utils:validate_map(Details, Spec, Extensions);
+    Opts = #{keep_unknown => true},
+    wamp_utils:validate_map(Details, Spec, Extensions, Opts);
 
 validate(invocation, Details, Extensions) ->
     Spec = ?INVOCATION_DETAILS_SPEC,


### PR DESCRIPTION
Extended validation options to keep all the content in `details` for `error` and `result`